### PR TITLE
feat(clientside axios): adds better axios configuration options

### DIFF
--- a/src/test/fixtures/test-schema.ts
+++ b/src/test/fixtures/test-schema.ts
@@ -20,6 +20,9 @@ export const testSchema = createHttpSchema({
     }),
     responseBody: z.unknown(),
   },
+  'GET /404': {
+    responseBody: z.object({ error: z.string() }),
+  },
   'PUT /multiply': {
     requestBody: z.object({ first: z.number(), second: z.number() }),
     responseBody: z.number(),

--- a/src/test/fixtures/test-server.ts
+++ b/src/test/fixtures/test-server.ts
@@ -44,6 +44,10 @@ export function createTestServer() {
     res.send(result);
   });
 
+  typedRoutes.get('/404', (req, res) => {
+    res.status(404).json({ error: 'Resource not found' });
+  });
+
   // Specify some route handlers separately and then add them to the app.
   const handleProduct = createRequestHandler({
     schema: testSchema,


### PR DESCRIPTION
* createApiClient now accepts full range of axios config options. 
* New default validateStatus passes all status codes below 500.

BREAKING CHANGE: apiClient returns standard axios response, with a data property correctly typed per
the schema. This means every usage of `apiClient` will need to be updated to access the `data` property on the AxiosResponse object.