### PR TITLE
Feat: Adds PATCH & DELETE and Improve client types

### DIFF
--- a/src/client/create-http-client.ts
+++ b/src/client/create-http-client.ts
@@ -1,6 +1,13 @@
 import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 import * as pathToRegExp from 'path-to-regexp';
-import { Anonymize, NamedParams, Paths, RequestBody, RequestBodyInput, ResponseBody } from '../util';
+import {
+  Anonymize,
+  NamedParams,
+  Paths,
+  RequestBody,
+  RequestBodyInput,
+  ResponseBody,
+} from '../util';
 import { HttpSchema, Method } from '../shared';
 
 /** Returns a strongly typed object for making requests to a remote HTTP server that implements the given `schema`. */

--- a/src/client/create-http-client.ts
+++ b/src/client/create-http-client.ts
@@ -39,9 +39,14 @@ export function createHttpClient<S extends HttpSchema>(
       .compile(path)(info?.params)
       .replace(/\*/g, () => info?.params[i++]);
 
+    // here we pick the schema definition from given method & path
+    // then we'll parse the response payload
+    // this will ensure we have correct types in the Frontend (e.g.: Date instance, not a string of date)
     const responseBodySchema = schema[`${method} ${path}`].responseBody;
 
     return axiosClient({ method, url, data: info?.body }).then((response) => {
+      // if we fail to parse here, mean our API is returning something weird
+      // an Exception would be thrown by Zod
       response.data = responseBodySchema.parse(response.data);
 
       return response;

--- a/src/shared/methods.ts
+++ b/src/shared/methods.ts
@@ -1,5 +1,5 @@
 /** HTTP Methods */
-export const methods = ['GET', 'POST', 'PUT'] as const;
+export const methods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'] as const;
 
 /** HTTP Methods */
 export type Method = typeof methods[number & keyof typeof methods];


### PR DESCRIPTION
There are 2 things that are being introduced in this PR

## Adds PATCH, DELETE

Up to now, RESTFul is still popular and widely used worldwide, thus `PATCH` & `DELETE` should be added. This would increase the package compatibility with userland's approaches.

## Parse the response body

Before, we blindly accept the response body and directly return it to userland. 

There is a small issue if we have `Date`.

Express will always transform the JS `Date` instances to strings (utilizing the toISOString)

![image](https://github.com/Skutopia-org/zod-http-schemas/assets/23478115/1b8b2e16-1d6e-4aed-a831-9537977f027d)
 
On the client side, we thought that we would have the correct `Date` instance but it isn't.

So adds logic to pick up the schema definition from the given method & path and parse the response body. This will ensure we have the correct response body & types before doing anything else.

Thank you.