### PR TITLE
Feat: peerDependencies for zod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [2.1.0](https://github.com/antman261/zod-http-schemas/compare/v2.0.0...v2.1.0) (2023-09-18)
+
+
+### Features
+
+* Adds PATCH & DELETE and Improve client types ([#6](https://github.com/antman261/zod-http-schemas/issues/6)) ([70add2b](https://github.com/antman261/zod-http-schemas/commit/70add2ba1fea00c429ae2fe89b905d1659edef10))
+* peer dependency and moved zod to devDependencies ([58b2eb7](https://github.com/antman261/zod-http-schemas/commit/58b2eb749fcad7e2d54fb0f94575536a4054e829))
+
 ### [2.0.3](https://github.com/Skutopia-org/zod-http-schemas/compare/v2.0.2...v2.0.3) (2023-09-12)
 Bump back `zod` package version to old version.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,7 @@
             "dependencies": {
                 "axios": "^0.21.1",
                 "express": "^4.17.1",
-                "path-to-regexp": "^4.0.2",
-                "zod": "^3.8.2"
+                "path-to-regexp": "^4.0.2"
             },
             "devDependencies": {
                 "@types/body-parser": "^1.19.0",
@@ -40,7 +39,11 @@
                 "prettier": "^2.4.0",
                 "standard-version": "^9.3.1",
                 "ts-node": "^8.6.2",
-                "typescript": "^4.4.2"
+                "typescript": "^4.4.2",
+                "zod": "^3.8.2"
+            },
+            "peerDependencies": {
+                "zod": "^3.8.2"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -10565,9 +10568,10 @@
             }
         },
         "node_modules/zod": {
-            "version": "3.22.2",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.2.tgz",
-            "integrity": "sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==",
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.8.2.tgz",
+            "integrity": "sha512-kpwVRACazsOhELVt5h4R2pC2OndrqaBK4+z134TWOsnzn7n2uOYnSyvx0QAn410pl28CgVtkSi5ew7e/AgO0oA==",
+            "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }
@@ -18714,9 +18718,10 @@
             "dev": true
         },
         "zod": {
-            "version": "3.22.2",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.2.tgz",
-            "integrity": "sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg=="
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.8.2.tgz",
+            "integrity": "sha512-kpwVRACazsOhELVt5h4R2pC2OndrqaBK4+z134TWOsnzn7n2uOYnSyvx0QAn410pl28CgVtkSi5ew7e/AgO0oA==",
+            "dev": true
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "zod-http-schemas",
-    "version": "2.0.3",
+    "version": "2.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "zod-http-schemas",
-            "version": "2.0.3",
+            "version": "2.1.0",
             "license": "MIT",
             "dependencies": {
                 "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -70,17 +70,20 @@
         "prettier": "^2.4.0",
         "standard-version": "^9.3.1",
         "ts-node": "^8.6.2",
-        "typescript": "^4.4.2"
+        "typescript": "^4.4.2",
+        "zod": "^3.8.2"
     },
     "dependencies": {
         "axios": "^0.21.1",
         "express": "^4.17.1",
-        "path-to-regexp": "^4.0.2",
-        "zod": "^3.8.2"
+        "path-to-regexp": "^4.0.2"
     },
     "config": {
         "commitizen": {
             "path": "./node_modules/cz-conventional-changelog"
         }
+    },
+    "peerDependencies": {
+        "zod": "^3.8.2"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "zod-http-schemas",
-    "version": "2.0.3",
+    "version": "2.1.0",
     "description": "Zod Powered, strongly-typed HTTP schemas",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Feature

- Added zod as peerDependencies
- Additionally, moved zod to devDependencies

This would allow userland to use newer zod version without any breaking