### PR TITLE
fix: Pass queryParams to the axios client

### DIFF
--- a/src/client/create-http-client.ts
+++ b/src/client/create-http-client.ts
@@ -51,7 +51,12 @@ export function createHttpClient<S extends HttpSchema>(
     // this will ensure we have correct types in the Frontend (e.g.: Date instance, not a string of date)
     const responseBodySchema = schema[`${method} ${path}`].responseBody;
 
-    return axiosClient({ method, url, data: info?.body }).then((response) => {
+    return axiosClient({
+      method,
+      url,
+      data: info?.body,
+      params: info?.queryParams
+    }).then((response) => {
       // if we fail to parse here, mean our API is returning something weird
       // an Exception would be thrown by Zod
       response.data = responseBodySchema.parse(response.data);

--- a/src/test/client-server.test.ts
+++ b/src/test/client-server.test.ts
@@ -84,6 +84,15 @@ describe('Implementing a HTTP client and server', () => {
     });
     await expect(res).eq('6');
   });
+  it('Passes query params on to the server', async () => {
+    const { data: res } = await client.post('/sum/with-query-param', {
+      body: [1, 2, 3],
+      queryParams: {
+        alsoAdd: 4
+      }
+    });
+    await expect(res).eq(10);
+  });
 });
 
 describe('HTTP Server without JSON parser', () => {

--- a/src/test/fixtures/test-schema.ts
+++ b/src/test/fixtures/test-schema.ts
@@ -46,6 +46,12 @@ export const testSchema = createHttpSchema({
       .int()
       .transform((s) => s.toString()),
   },
+  'POST /sum/with-query-param': {
+    requestBody: z.array(z.number().int()),
+    responseBody: z
+      .number()
+      .int(),
+  },
 });
 
 // Used for testing get request without json body parser

--- a/src/test/fixtures/test-server.ts
+++ b/src/test/fixtures/test-server.ts
@@ -115,6 +115,11 @@ export function createTestServer() {
     const result = numbers.reduce((acc, val) => acc + val, 0);
     res.send(result);
   });
+  typedRoutes.post('/sum/with-query-param', async (req, res) => {
+    const numbers = req.body;
+    const result = numbers.reduce((acc, val) => acc + val, 0) + parseInt(req.query.alsoAdd as string);
+    res.send(result);
+  });
 
   // Create an Express Application and add middleware to it, including our HTTP schema implementation.
   const app = express();


### PR DESCRIPTION
## Problem/motivation

I have some endpoints that depend on query params. When creating clients, it looks like these params are not passed on to the axios client and thus are never reaching the server.

## Solution

Pass queryParams on as params, as documented by one of the comments:

```
    // Create the actual URL by substituting params (if any) into the path pattern.
    // NB: what axios calls `params` are really queryparams, so different from our `params`,
```

Note: the tests weren't passing for me, but `client-server.test.ts` looks like the right place to add a test case for this. Maybe HEAD is broken or it's just my envo?

A test cases has been added, the whole suite should pass after #13.

## Follow-ups

The cast required in the route handler (`req.query.alsoAdd as string`) does indicate there may be some type definition stuff that could be added to the query param system?