### PR TITLE
fix: Get `client-server.test.ts` passing

### DIFF
--- a/src/test/client-server.test.ts
+++ b/src/test/client-server.test.ts
@@ -79,8 +79,6 @@ describe('Implementing a HTTP client and server', () => {
     await expect(res).eq(6);
   });
   it('Type transformations work as expected for response bodies', async () => {
-    // A number transformed into a string will fail validation at the client until
-    // the type specifies .pipe(z.string()).
     await expect(client.post('/sum/transform-response', {
       body: [1, 2, 3]
     })).to.be.rejectedWith(JSON.stringify([

--- a/src/test/client-server.test.ts
+++ b/src/test/client-server.test.ts
@@ -74,7 +74,7 @@ describe('Implementing a HTTP client and server', () => {
   });
   it('Type transformations work as expected for request bodies', async () => {
     const { data: res } = await client.post('/sum/transform-string', {
-      body: ['1', '2', '3']
+      body: ['1', '2', '3'],
     });
     await expect(res).eq(6);
   });

--- a/src/test/client-server.test.ts
+++ b/src/test/client-server.test.ts
@@ -74,15 +74,24 @@ describe('Implementing a HTTP client and server', () => {
   });
   it('Type transformations work as expected for request bodies', async () => {
     const { data: res } = await client.post('/sum/transform-string', {
-      body: ['1', '2', '3'],
+      body: ['1', '2', '3']
     });
     await expect(res).eq(6);
   });
   it('Type transformations work as expected for response bodies', async () => {
-    const { data: res } = await client.post('/sum/transform-response', {
-      body: [1, 2, 3],
-    });
-    await expect(res).eq('6');
+    // A number transformed into a string will fail validation at the client until
+    // the type specifies .pipe(z.string()).
+    await expect(client.post('/sum/transform-response', {
+      body: [1, 2, 3]
+    })).to.be.rejectedWith(JSON.stringify([
+      {
+        code: 'invalid_type',
+        expected: 'number',
+        received: 'string',
+        path: [],
+        message: 'Expected number, received string'
+      }
+    ], null, 2));
   });
 });
 

--- a/src/test/fixtures/test-schema.ts
+++ b/src/test/fixtures/test-schema.ts
@@ -2,13 +2,18 @@ import { createHttpSchema, z } from '../../shared';
 import { errorUtil } from 'zod/lib/helpers/errorUtil';
 import toString = errorUtil.toString;
 
+const customValidationErrorResponse = z.object({
+  success: z.literal(false),
+  code: z.literal('MY_CUSTOM_VALIDATION_ERROR'),
+});
+
 export const testSchema = createHttpSchema({
   'GET /random-numbers': {
     responseBody: z.array(z.number()),
   },
   'POST /sum': {
     requestBody: z.array(z.number()),
-    responseBody: z.number(),
+    responseBody:  z.number().or(customValidationErrorResponse),
   },
   'POST /product': {
     requestBody: z.array(z.number()),
@@ -29,7 +34,7 @@ export const testSchema = createHttpSchema({
   },
   'POST /sum/negative': {
     requestBody: z.array(z.number().int().negative()),
-    responseBody: z.number().negative().int(),
+    responseBody: z.number().negative().int().or(customValidationErrorResponse),
   },
   'POST /sum/negative-broken': {
     requestBody: z.array(z.number().int().negative()),


### PR DESCRIPTION
## Problem/motivation

The tests are failing! I suspect based on the failures, they were passing before response bodies from the server were validated on the HTTP client side.

## Solution

Two test cases were fixed, by adding the `MY_CUSTOM_VALIDATION_ERROR` object to the response schema.

The last test case was fixed by asserting a type error was thrown on the client, for a number transformed into a string:

```
    responseBody: z
      .number()
      .int()
      .transform((s) => s.toString()),
```

For types like the following, I don't know how this would actually end up being supported if the client and server share the same type definition. I guess both would assume you are starting with a number, but that would only ever be true on the server 🤔 

If this logic holds, the test case stands an example of how transformations _can't_ work with the current architecture.