### PR TITLE
[TEC-1086] Add support for "requestProps" and zod v4

### DIFF
--- a/src/server/create-request-handler.ts
+++ b/src/server/create-request-handler.ts
@@ -15,6 +15,7 @@ import {
 } from '../util';
 import { HttpSchema, Method } from '../shared';
 import { ZodType, ZodTypeAny } from 'zod/v3';
+import { ZodTypeAnyVersion } from '../shared/AnyVersionZodType';
 
 /**
  * Accepts and returns a request handler function that is strongly-typed to match the given schema definition for the
@@ -28,7 +29,7 @@ export function createRequestHandler<S extends HttpSchema, R extends keyof S>(
 export function createRequestHandler<
   S extends HttpSchema,
   R extends keyof S,
-  ReqProps extends ZodTypeAny = ZodType<{}>
+  ReqProps extends ZodTypeAnyVersion = ZodType<{}>
 >(options: {
   schema: S;
   route: R;

--- a/src/server/decorate-express-router.ts
+++ b/src/server/decorate-express-router.ts
@@ -16,7 +16,7 @@ import { ZodTypeAnyVersion } from '../shared/AnyVersionZodType';
 export interface DecorateExpressRouterOptions<
   Schema extends HttpSchema,
   App extends IRouter,
-  ReqProps extends ZodTypeAny
+  ReqProps extends ZodTypeAnyVersion
 > {
   /** Type schema describing the endpoints handled by the express server. */
   schema: Schema;
@@ -41,7 +41,7 @@ export interface DecorateExpressRouterOptions<
 export function decorateExpressRouter<
   Schema extends HttpSchema,
   App extends IRouter,
-  ReqProps extends ZodTypeAny = ZodType<{}>
+  ReqProps extends ZodTypeAnyVersion = ZodType<{}>
 >(options: DecorateExpressRouterOptions<Schema, App, ReqProps>) {
   // Return a new app/router with some overridden methods. The original app/router is left unchanged.
   let router = options.router ?? express.Router();
@@ -117,7 +117,7 @@ export function decorateExpressRouter<
 export type DecoratedExpressRouter<
   S extends HttpSchema,
   R extends IRouter,
-  ReqProps extends ZodTypeAny
+  ReqProps extends ZodTypeAnyVersion
 > = ExpressRequestHandler &
   Omit<R, Lowercase<Method>> & {
     [M in Method as Lowercase<M>]: <P extends Paths<S, M>>(
@@ -131,7 +131,7 @@ export type DecoratedExpressRouter<
 
 /** Creates a middleware function that validates request properties against the given schema. */
 function createRequestPropValidationMiddleware(
-  requestProps: ZodTypeAny
+  requestProps: ZodTypeAnyVersion
 ): ExpressRequestHandler {
   return (req, _, next) => {
     requestProps.parse(req);

--- a/src/test/fixtures/test-server.ts
+++ b/src/test/fixtures/test-server.ts
@@ -6,7 +6,7 @@ import * as useragent from 'express-useragent';
 import * as http from 'http';
 import * as morgan from 'morgan';
 import { createRequestHandler, decorateExpressRouter } from '../../server';
-import { z } from 'zod/v3';
+import { z } from 'zod/v4';
 
 // Comment out the following imports to test with a zod v4 schema:
 import { testGetOnlySchema, testSchema } from './test-schema';

--- a/src/test/fixtures/test-server.ts
+++ b/src/test/fixtures/test-server.ts
@@ -6,7 +6,7 @@ import * as useragent from 'express-useragent';
 import * as http from 'http';
 import * as morgan from 'morgan';
 import { createRequestHandler, decorateExpressRouter } from '../../server';
-import { z } from 'zod/v4';
+import { z } from 'zod/v3';
 
 // Comment out the following imports to test with a zod v4 schema:
 import { testGetOnlySchema, testSchema } from './test-schema';


### PR DESCRIPTION
## Motivation

Missed this in the initial migration.

## Solution

Validated this with:

```diff
diff --git a/src/test/fixtures/test-server.ts b/src/test/fixtures/test-server.ts
index a5a551f..385bfa0 100644
--- a/src/test/fixtures/test-server.ts
+++ b/src/test/fixtures/test-server.ts
@@ -6,7 +6,7 @@ import * as useragent from 'express-useragent';
 import * as http from 'http';
 import * as morgan from 'morgan';
 import { createRequestHandler, decorateExpressRouter } from '../../server';
-import { z } from 'zod/v3';
+import { z } from 'zod/v4';
 
 // Comment out the following imports to test with a zod v4 schema:
 import { testGetOnlySchema, testSchema } from './test-schema';
```

Builds and tests pass when defining request props in a v4 schema.


## Type

Multiple types can be selected

- [ ] Feature 🚀
- [x] Bug 🐛
- [ ] Improvement 🍻
- [ ] Tech Debt 🧰
- [ ] [Papercut](https://skutopia.atlassian.net/wiki/spaces/SKUT/pages/1249280166/Papercut+pull+requests)

## Checklist

- Linear: <ticket number if not included in branch name>
- Paired with: <name of people paired with for this PR>
