### PR TITLE
[papercut] Log invalid data that triggers zod errors

### DIFF
--- a/src/client/create-http-client.ts
+++ b/src/client/create-http-client.ts
@@ -55,11 +55,20 @@ export function createHttpClient<S extends HttpSchema>(
       method,
       url,
       data: info?.body,
-      params: info?.queryParams
+      params: info?.queryParams,
     }).then((response) => {
       // if we fail to parse here, mean our API is returning something weird
       // an Exception would be thrown by Zod
-      response.data = responseBodySchema.parse(response.data);
+      try {
+        response.data = responseBodySchema.parse(response.data);
+      } catch (e) {
+        console.error(
+          `Invalid input triggered zod parsing error: ${JSON.stringify(
+            response.data
+          )}`
+        );
+        throw e;
+      }
 
       return response;
     });


### PR DESCRIPTION
## Motivation

When a client throws because of invalid data, the error is a little cryptic:

```
     ZodError: [
  {
    "code": "invalid_union",
    "errors": [
      [
        {
          "expected": "object",
          "code": "invalid_type",
          "path": [],
          "message": "Invalid input: expected object, received string"
        }
      ],
```

## Solution

This PR does a console.error with the invalid data, to help debug what aspect of the received payload isn't conforming to the zod schema.

## Type

Multiple types can be selected

- [ ] Feature 🚀
- [ ] Bug 🐛
- [x] Improvement 🍻
- [ ] Tech Debt 🧰
- [ ] [Papercut](https://skutopia.atlassian.net/wiki/spaces/SKUT/pages/1249280166/Papercut+pull+requests)

## Checklist

- Linear: <ticket number if not included in branch name>
- Paired with: <name of people paired with for this PR>
