### PR TITLE
[PAPERCUT] expose axios instance on HttpClient for interceptor use

### DIFF
--- a/src/client/create-http-client.ts
+++ b/src/client/create-http-client.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
+import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 import * as pathToRegExp from 'path-to-regexp';
 import {
   Anonymize,
@@ -26,6 +26,7 @@ export function createHttpClient<S extends HttpSchema>(
     put: (path, info?) => request('PUT', path, info),
     patch: (path, info?) => request('PATCH', path, info),
     delete: (path, info?) => request('DELETE', path, info),
+    instance: axiosClient,
   };
 
   async function request(
@@ -85,6 +86,9 @@ export type HttpClient<S extends HttpSchema> = {
       ? [RequestInfo<S, M, P>?] // make the `info` arg optional if this route has no params/body
       : [RequestInfo<S, M, P>] // make the `info` arg required if this route does have params/body
   ) => Promise<AxiosResponse<ResponseBody<S, M, P>>>;
+} & {
+  /** Underlying axios instance — exposed for consumers who need to add interceptors, modify defaults, etc. */
+  instance: AxiosInstance;
 };
 
 /** Strongly-typed object used to provide details for a HTTP request to a specific route. */


### PR DESCRIPTION
## Motivation

HttpClient had no way to attach per-request behaviour (e.g. auth headers) without reaching into internals or hacking axios options.

## Solution

Expose the underlying AxiosInstance on HttpClient<S> so consumers can attach interceptors idiomatically.

## Outcomes

Consumers can now set per-request headers via client.instance.interceptors.request.use(...) without type casts or workarounds.

## Type

Multiple types can be selected

- [ ] Feature 🚀
- [ ] Bug 🐛
- [ ] Improvement 🍻
- [ ] Tech Debt 🧰
- [x] [Papercut](https://skutopia.atlassian.net/wiki/spaces/SKUT/pages/1249280166/Papercut+pull+requests)

## Checklist

- Linear: <ticket number if not included in branch name>
- Paired with: <name of people paired with for this PR>
