### PR TITLE
[TEC-1110] Allow clients to skip parsing responses

### DIFF
--- a/src/client/create-http-client.ts
+++ b/src/client/create-http-client.ts
@@ -35,6 +35,7 @@ export function createHttpClient<S extends HttpSchema>(
       params?: any;
       body?: any;
       queryParams?: AxiosRequestConfig['params'];
+      skipClientValidation?: boolean;
     }
   ) {
     // Create the actual URL by substituting params (if any) into the path pattern.
@@ -57,6 +58,9 @@ export function createHttpClient<S extends HttpSchema>(
       data: info?.body,
       params: info?.queryParams,
     }).then((response) => {
+      if (info?.skipClientValidation) {
+        return response;
+      }
       // if we fail to parse here, mean our API is returning something weird
       // an Exception would be thrown by Zod
       try {
@@ -93,12 +97,15 @@ type RequestInfo<
   M extends Method,
   P extends S[keyof S]['path'] = string
 > = Anonymize<
-  (HasNamedParams<S, M, P> extends true
+  ((HasNamedParams<S, M, P> extends true
     ? { params: Record<NamedParams<S, M, P>, string> } // make `params` required if this route does have named params
     : { params?: Record<string, never> }) & // make `params` optional if this route has no named params
     (HasBody<S, M, P> extends true
       ? { body: RequestBodyInput<S, M, P> } // make `body` required if this route does have a body
-      : { body?: never }) & { queryParams?: AxiosRequestConfig['params'] } // make `body` optional if this route has no body
+      : { body?: never }) & { queryParams?: AxiosRequestConfig['params'] }) & {
+    // make `body` optional if this route has no body
+    skipClientValidation?: boolean;
+  }
 >;
 
 /** Helper type that resolves to `true` if the route for the given method/path has defined namedParams. */

--- a/src/test/client-server.test.ts
+++ b/src/test/client-server.test.ts
@@ -100,6 +100,13 @@ describe('Implementing a HTTP client and server', () => {
       )
     );
   });
+  it('It allows clients to skip zod parsing', async () => {
+    const response = await client.post('/sum/transform-response', {
+      body: [1, 2, 3],
+      skipClientValidation: true,
+    });
+    expect(response.data).to.equal('6');
+  });
   it('Passes query params on to the server', async () => {
     const { data: res } = await client.post('/sum/with-query-param', {
       body: [1, 2, 3],


### PR DESCRIPTION
## Motivation

This is helpful for the migration I am doing, in cases where we are explicitly breaking the contract, but still want to use the HTTP client.

## Type

Multiple types can be selected

- [X] Feature 🚀
- [ ] Bug 🐛
- [ ] Improvement 🍻
- [ ] Tech Debt 🧰
- [ ] [Papercut](https://skutopia.atlassian.net/wiki/spaces/SKUT/pages/1249280166/Papercut+pull+requests)

## Checklist

- Linear: <ticket number if not included in branch name>
- Paired with: <name of people paired with for this PR>
